### PR TITLE
Replacing ICU4NET with icu-dotnet

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <add key="icunet" value="https://www.myget.org/F/icu-dotnet/api/v3/index.json" />
     <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/" />
   </packageSources>
 </configuration>

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayIterator.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/CharArrayIterator.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using ICU4NET;
+using Icu;
 
 namespace Lucene.Net.Analysis.Util
 {

--- a/src/Lucene.Net.Analysis.Common/Analysis/Util/ICharacterIterator.cs
+++ b/src/Lucene.Net.Analysis.Common/Analysis/Util/ICharacterIterator.cs
@@ -1,8 +1,7 @@
-﻿using System;
-
+﻿
 namespace Lucene.Net.Analysis.Util
 {
-    public interface ICharacterIterator : ICloneable
+    public interface ICharacterIterator
     {
         char First();
         char Last();

--- a/src/Lucene.Net.Analysis.Common/Lucene.Net.Analysis.Common.Portable.csproj
+++ b/src/Lucene.Net.Analysis.Common/Lucene.Net.Analysis.Common.Portable.csproj
@@ -53,6 +53,12 @@
     <None Include="Lucene.Net.Analysis.Common.Portable.project.json" />
     <!-- A reference to the entire .NET Framework is automatically included -->
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Lucene.Net.Core\Lucene.Net.Portable.csproj">
+      <Project>{dbc3b677-805c-430e-af78-a9abf3975d17}</Project>
+      <Name>Lucene.Net.Portable</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Lucene.Net.Analysis.Common/Lucene.Net.Analysis.Common.Portable.project.json
+++ b/src/Lucene.Net.Analysis.Common/Lucene.Net.Analysis.Common.Portable.project.json
@@ -4,7 +4,7 @@
     "dnxcore50.app": {}
   },
   "dependencies": {
-    "Lucene.Net.Portable": "",
+    "icu.net": "1.0.0",
     "Microsoft.NETCore": "5.0.1-beta-23516",
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1-beta-23516"
   },


### PR DESCRIPTION
This fixes the project `Lucene.Net.Analysis.Common` by replacing [ICU4NET](https://github.com/niaher/icu4net) with [icu-dotnet](https://github.com/sillsdev/icu-dotnet).

There is a separate PR [conniey/icu-dotnet](https://github.com/conniey/icu-dotnet/tree/portToNETCore) that I need to merge into [icu-dotnet](https://github.com/sillsdev/icu-dotnet).