### PR TITLE
Compiling and running on linux

### DIFF
--- a/src/Lucene.Net.Analysis.Common/project.json
+++ b/src/Lucene.Net.Analysis.Common/project.json
@@ -12,7 +12,7 @@
       "includeFiles": [
         "Analysis/Gl/galician.rslp",
         "Analysis/Pt/portuguese.rslp",
-        "Analysis/Compound/hyphenation/hyphenation.dtd"
+        "Analysis/Compound/Hyphenation/hyphenation.dtd"
       ]
     },
     "compile": {

--- a/src/Lucene.Net.Analysis.Common/project.json
+++ b/src/Lucene.Net.Analysis.Common/project.json
@@ -12,7 +12,7 @@
       "includeFiles": [
         "Analysis/Gl/galician.rslp",
         "Analysis/Pt/portuguese.rslp",
-        "Analysis/Compound/Hyphenation/hyphenation.dtd"
+        "Analysis/Compound/hyphenation/hyphenation.dtd"
       ]
     },
     "compile": {

--- a/src/Lucene.Net.Core/Util/Constants.cs
+++ b/src/Lucene.Net.Core/Util/Constants.cs
@@ -202,6 +202,13 @@ namespace Lucene.Net.Util
                     return Environment.OSVersion.ToString();
 #endif
                 }
+				
+#if NETSTANDARD
+                if (variable == "PROCESSOR_ARCHITECTURE") {
+
+                    return RuntimeInformation.OSArchitecture.ToString();
+                }
+#endif
 
                 return System.Environment.GetEnvironmentVariable(variable);
             }

--- a/src/Lucene.Net.Core/Util/Constants.cs
+++ b/src/Lucene.Net.Core/Util/Constants.cs
@@ -205,7 +205,6 @@ namespace Lucene.Net.Util
 				
 #if NETSTANDARD
                 if (variable == "PROCESSOR_ARCHITECTURE") {
-
                     return RuntimeInformation.OSArchitecture.ToString();
                 }
 #endif


### PR DESCRIPTION
- Fixed getting os arch which cause null ref during diagnostic info serialization:

```
$ dotnet run
Project Lucene (.NETCoreApp,Version=v1.0) was previously compiled. Skipping compilation.

Unhandled Exception: System.NullReferenceException: Object reference not set to an instance of an object.
   at Lucene.Net.Store.DataOutput.WriteString(String s)
   at Lucene.Net.Store.DataOutput.WriteStringStringMap(IDictionary`2 map)
   at Lucene.Net.Codecs.Lucene46.Lucene46SegmentInfoWriter.Write(Directory dir, SegmentInfo si, FieldInfos fis, IOContext ioContext)
   at Lucene.Net.Index.DocumentsWriterPerThread.SealFlushedSegment(FlushedSegment flushedSegment)
   at Lucene.Net.Index.DocumentsWriterPerThread.Flush()
   at Lucene.Net.Index.DocumentsWriter.DoFlush(DocumentsWriterPerThread flushingDWPT)
   at Lucene.Net.Index.DocumentsWriter.FlushAllThreads(IndexWriter indexWriter)
   at Lucene.Net.Index.IndexWriter.DoFlush(Boolean applyAllDeletes)
   at Lucene.Net.Index.IndexWriter.Flush(Boolean triggerMerge, Boolean applyAllDeletes)
   at Lucene.Program.Main(String[] args)
```