### PR TITLE
Fixing TypeInitializationException in Configuration 

### DIFF
--- a/src/Lucene.Net.Core/Support/Configuration/Configuration.cs
+++ b/src/Lucene.Net.Core/Support/Configuration/Configuration.cs
@@ -17,17 +17,14 @@ namespace Lucene.Net.Support.Configuration
         {
             var builder = new ConfigurationBuilder();
             var entryAssembly = Assembly.GetEntryAssembly();
-            var configurationFiles = new string[0];
 
             if (entryAssembly != null)
             {
                 var directory = Path.GetDirectoryName(entryAssembly.Location);
-                configurationFiles = Directory.GetFiles(directory, "*.config");
-            }
-
-            foreach (var config in configurationFiles)
-            {
-                builder.AddConfigFile(config, false, new KeyValueParser());
+                foreach (var config in Directory.EnumerateFiles(directory, "*.config"))
+                {
+                    builder.AddConfigFile(config, false, new KeyValueParser());
+                }
             }
 
             _configuration = builder.Build();

--- a/src/Lucene.Net.Core/Support/Configuration/KeyValueParser.cs
+++ b/src/Lucene.Net.Core/Support/Configuration/KeyValueParser.cs
@@ -84,7 +84,7 @@ namespace Lucene.Net.Support.Configuration
             var key = element.Attribute(_keyName);
             var value = element.Attribute(_valueName);
 
-            if (key == null)
+            if (key == null || value == null)
             {
                 return;
             }
@@ -94,16 +94,7 @@ namespace Lucene.Net.Support.Configuration
             switch (action)
             {
                 case ConfigurationAction.Add:
-                    string valueToAdd = value.Value;
-
-                    if (results.ContainsKey(fullkey))
-                    {
-                        results[fullkey] = valueToAdd;
-                    }
-                    else
-                    {
-                        results.Add(fullkey, valueToAdd);
-                    }
+                    results[fullkey] = value.Value;
                     break;
                 case ConfigurationAction.Remove:
                     results.Remove(fullkey);


### PR DESCRIPTION
Hello,
I have encountered same issue as [@Metamorphus](https://github.com/Metamorphus)
The issue can be reproduced with following steps:
1. create dotnet core web project
2. add references to lucene-4.8.0-alpha
3. create controller with some basic lucene functions - add to index & search
4. deploy the project to iis

This issue occurs when lucene tries parsing web.config file. But there might be other config files for loggers ...
Caused by null value when parsing config files. 